### PR TITLE
Openapi.yamlからget-imageとget-movieを削除したため，frontendのapi.tsを修正 #83

### DIFF
--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,14 +1,13 @@
 import axios from 'axios';
-import { TrialsApi, ImagesApi } from './schema';
+import { TrialsApi } from './schema';
 
+const BASEURL = process.env.BACKEND_ENDPOINT
 const api = axios.create({
-  baseURL: 'http://localhost:3000'
+  baseURL: BASEURL
 });
 
-const trialsApi = new TrialsApi(undefined, 'http://localhost:3000', api)
-const imagesApi = new ImagesApi(undefined, 'http://localhost:3000', api)
+const trialsApi = new TrialsApi(undefined, BASEURL, api)
 
 export {
-  trialsApi,
-  imagesApi
+  trialsApi
 }


### PR DESCRIPTION
 以下のタスクチケットで修正漏れがあったため，直しました．
api.tsのImagesAPIが存在しないというエラーを吐いていたため，削除することにより対応しました．
- #72 